### PR TITLE
fix: variable substitution using latest ui bundle

### DIFF
--- a/dev-site.yml
+++ b/dev-site.yml
@@ -19,7 +19,7 @@ asciidoc:
     - ./lib/tab-block.js
 ui:
   bundle:
-    url: https://github.com/redhat-developer-demos/rhd-tutorial-ui/releases/download/v0.1.9/ui-bundle.zip
+    url: https://github.com/redhat-scholars/course-ui/releases/download/v0.1.12/ui-bundle.zip
     snapshot: true
   supplemental_files: ./supplemental-ui
 output:

--- a/site.yml
+++ b/site.yml
@@ -21,7 +21,7 @@ asciidoc:
 
 ui:
   bundle:
-    url: https://github.com/redhat-developer-demos/rhd-tutorial-ui/releases/download/v0.1.9/ui-bundle.zip
+    url: https://github.com/redhat-scholars/course-ui/releases/download/v0.1.12/ui-bundle.zip
     snapshot: true
   supplemental_files:
     - path: ./supplemental-ui


### PR DESCRIPTION
This PR fixes variable substitution, but also raises a question. Should we be using redhat-developer-demos/rhd-tutorial-ui or redhat-scholars/course-ui as the UI bundle source of truth?