### PR TITLE
:gift_heart: PR Previews!

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,44 +1,118 @@
-name: docs
+name: Docs
 
 on:
   push:
     branches:
       - master
+      - main
+  pull_request:
+    branches:
+      - '**'
+
 env:
   SITE_DIR: "gh-pages"
+
 jobs:
   build_site:
     name: "Build site with Antora"
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-22.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Generate site using antora site action"
         uses: kameshsampath/antora-site-action@master
         with:
           antora_playbook: site.yml
       - name: "Upload generated site"
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: site
           path: "${{ github.workspace }}/${{ env.SITE_DIR }}"
+
   deploy_site:
-    runs-on: [ubuntu-latest]
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+      id-token: write
+    runs-on: [ubuntu-22.04]
     needs: [build_site]
     name: "Deploy GitHub Pages"
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Download generated site
         uses: actions/download-artifact@v4
         with:
           name: site
           path: "${{ github.workspace }}/${{ env.SITE_DIR }}"
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@3.2.1
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          # ACCESS_TOKEN: # optional
-          GITHUB_TOKEN: "${{ github.token}}"
-          FOLDER: "${{ env.SITE_DIR }}"
-          BRANCH: "gh-pages"
-          COMMIT_MESSAGE: "[CI] Publish Documentation for ${{ github.sha }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: "${{ env.SITE_DIR }}"
+          keep_files: true
+          commit_message: "[CI] Publish Documentation for ${{ github.sha }}"
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+  # Based on : https://daiyi.co/blog/pr-previews-for-github-pages/
+  deploy_preview:
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+      id-token: write
+    env:
+      PR_PATH: pull-${{ github.event.number }}
+    runs-on: [ ubuntu-22.04 ]
+    needs: [ build_site ]
+    name: "Deploy preview for PR"
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Comment on PR
+        uses: hasura/comment-progress@v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          number: ${{ github.event.number }}
+          id: deploy-preview
+          message: "Starting deployment of preview for ${{ github.event.pull_request.head.sha }} ⏳..."
+
+      - name: Set base URL for preview
+        run: echo "BASE_URL=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.PR_PATH }}" >> "$GITHUB_ENV"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download generated site
+        uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: "${{ github.workspace }}/${{ env.SITE_DIR }}"
+
+      - name: Deploy PR preview
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: "${{ env.SITE_DIR }}"
+          destination_dir: "${{ env.PR_PATH }}"
+          commit_message: "[CI] Publish Preview for PR #${{ github.event.number }}"
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Update comment
+        uses: hasura/comment-progress@v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          number: ${{ github.event.number }}
+          id: deploy-preview
+          message: |
+            A preview of ${{ github.event.pull_request.head.sha }} is uploaded and can be seen here:
+            
+            ✨ ${{ env.BASE_URL }} ✨
+            
+            Changes may take a few minutes to propagate.
+            
+            The source is here: https://github.com/${{ github.repository }}/tree/gh-pages/${{ env.PR_PATH }}

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -1,0 +1,39 @@
+name: PR Close
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete_preview:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Delete preview for PR
+    runs-on: [ ubuntu-22.04 ]
+    env:
+      SITE_DIR: "gh-pages"
+      PR_PATH: pull-${{ github.event.number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Make empty dir
+        run: "mkdir -p ${{ env.SITE_DIR }}"
+
+      - name: Removing PR preview
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: "${{ env.SITE_DIR }}"
+          destination_dir: "${{ env.PR_PATH }}"
+          commit_message: "[CI] Delete Preview for PR #${{ github.event.number }}"
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Comment on PR
+        uses: hasura/comment-progress@v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          number: ${{ github.event.number }}
+          id: deploy-preview
+          message: "🪓 PR closed, deleted preview at https://github.com/${{ github.repository }}/tree/gh-pages/${{ env.PR_PATH }}"


### PR DESCRIPTION
While working on https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/1 I've wanted to have a PR preview, so I made one using https://daiyi.co/blog/pr-previews-for-github-pages as inspiration.

It works really well, and I thought to share it with the upstream template as well.

It generates a preview build, and publishes it on GH Pages in a subdirectory. The PR is commented to allow easy access to the preview link.

After the PR is merged, the preview is removed. The generation of the main documentation, doesn't remove the PR previews, so it's safe to work in parallel.

Refs:

- https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/2
- https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/3
- https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/4
- https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/5
- https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/6
- https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/7
- https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/8